### PR TITLE
docs: add contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS
+
+This repository contains the Go sources for REPLbot.
+
+## Development
+
+- Use Go 1.17 or newer.
+- Format Go code with `go fmt` (or `make fmt`) before committing.
+- Run unit tests with `go test ./...`. Many tests need `tmux`, `vim`, `asciinema`, and `ttyd`; they can be installed the same way as in `.github/workflows/test.yaml`.
+- For a full suite of checks including vetting and linting, run `make check`.
+
+## Commit Guidelines
+
+- Keep commit messages concise and descriptive.
+- Update documentation and examples when behavior or configuration options change.
+


### PR DESCRIPTION
## Summary
- document development and commit guidelines for contributors in AGENTS.md

## Testing
- `go test ./...` *(fails: exec format error in bot tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ff62d1f2c8325887aad38159e877b