### PR TITLE
build: use multi-stage Docker build with pinned deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
-FROM docker
-MAINTAINER Philipp C. Heckel <philipp.heckel@gmail.com>
-RUN apk add tmux asciinema ttyd
-COPY replbot /usr/bin
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o /replbot
+
+FROM alpine:3.19
+
+RUN apk add --no-cache tmux=3.3a_git20230428-r0 asciinema=2.4.0-r0 ttyd=1.7.4-r0
+
+COPY --from=builder /replbot /usr/bin/replbot
 
 ENTRYPOINT ["replbot"]


### PR DESCRIPTION
## Summary
- build binary in a golang:1.22-alpine builder stage
- run on minimal alpine:3.19 with pinned runtime deps
- drop deprecated maintainer label

## Testing
- `go test ./...` *(fails: exec format error; multiple TestBot* tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ff898bd248325a7452d2ce616e22a