### PR TITLE
Use crypto/rand for random strings

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -247,8 +247,12 @@ func (b *Bot) parseSessionConfig(ev *messageEvent) (*sessionConfig, error) {
 					return nil, err
 				}
 				conf.script = shareServerScriptFile
+				user, err := util.RandomString(10)
+				if err != nil {
+					return nil, err
+				}
 				conf.share = &shareConfig{
-					user:          util.RandomString(10),
+					user:          user,
 					relayPort:     relayPort,
 					hostKeyPair:   hostKeyPair,
 					clientKeyPair: clientKeyPair,

--- a/bot/session.go
+++ b/bot/session.go
@@ -141,10 +141,13 @@ var (
 // session represents a REPL session
 //
 // Slack:
-//   Channels and DMs have an ID (fields: Channel, Timestamp), and may have a ThreadTimestamp field
-//   to identify if they belong to a thread.
+//
+//	Channels and DMs have an ID (fields: Channel, Timestamp), and may have a ThreadTimestamp field
+//	to identify if they belong to a thread.
+//
 // Discord:
-//   Channels, DMs and Threads are all channels with an ID
+//
+//	Channels, DMs and Threads are all channels with an ID
 type session struct {
 	conf           *sessionConfig
 	conn           conn
@@ -929,7 +932,11 @@ func (s *session) startWeb(writable bool) error {
 		s.webPort = webPort
 	}
 	if s.webPrefix == "" {
-		s.webPrefix = util.RandomString(10)
+		p, err := util.RandomString(10)
+		if err != nil {
+			return err
+		}
+		s.webPrefix = p
 	}
 	s.webWritable = writable
 	var args []string

--- a/bot/session_test.go
+++ b/bot/session_test.go
@@ -102,9 +102,13 @@ func TestSessionResize(t *testing.T) {
 func createSession(t *testing.T, script string) (*session, *memConn) {
 	conf := createConfig(t)
 	conn := newMemConn(conf)
+	randID, err := util.RandomString(5)
+	if err != nil {
+		t.Fatal(err)
+	}
 	sconfig := &sessionConfig{
 		global:      conf,
-		id:          "sess_" + util.RandomString(5),
+		id:          "sess_" + randID,
 		user:        "phil",
 		control:     &channelID{"channel", "thread"},
 		terminal:    &channelID{"channel", ""},


### PR DESCRIPTION
## Summary
- read random bytes from `crypto/rand` instead of `math/rand`
- propagate errors from random string generation

## Testing
- `go test ./...` *(fails: tmux executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff8a409048325910db5f59e256d24