### PR TITLE
Add Docker-based test environment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,19 +4,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.x'
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install test dependencies
-        run: |
-          sudo apt-get install tmux vim asciinema
-          wget https://github.com/tsl0922/ttyd/releases/download/1.6.3/ttyd.x86_64
-          chmod +x ttyd.x86_64
-          sudo mv ttyd.x86_64 /usr/local/bin/ttyd
+      - name: Build test image
+        run: docker build -t replbot-test -f Dockerfile.test .
       - name: Run tests, formatting, vetting and linting
-        run: make check
+        run: docker run --rm replbot-test make check
       - name: Run and upload coverage to codecov.io
-        run: make coverage coverage-upload
+        run: docker run --rm replbot-test make coverage coverage-upload

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,21 @@
+FROM golang:1.22-alpine
+
+# Install tools required for running tests
+RUN apk add --no-cache \
+    bash \
+    make \
+    git \
+    curl \
+    tmux \
+    vim \
+    asciinema \
+    ttyd
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+CMD ["go", "test", "./..."]


### PR DESCRIPTION
## Summary
- add Dockerfile.test with all tools needed to run tests
- update test workflow to build and run tests inside the container

## Testing
- `go test ./...` *(fails: hung, interrupted)*
- `docker build -t replbot-test -f Dockerfile.test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ffcbcbb148325be276a2d4fda8fb7