### PR TITLE
chore: refresh lint tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  make fmt                         - Run 'go fmt'"
 	@echo "  make fmt-check                   - Run 'go fmt', but don't change anything"
 	@echo "  make vet                         - Run 'go vet'"
-	@echo "  make lint                        - Run 'golint'"
+	@echo "  make lint                        - Run 'golangci-lint'"
 	@echo "  make staticcheck                 - Run 'staticcheck'"
 	@echo
 	@echo "Build:"
@@ -35,7 +35,6 @@ help:
 	@echo "Install locally (requires sudo):"
 	@echo "  make install                     - Copy binary from dist/ to /usr/bin"
 	@echo "  make install-deb                 - Install .deb from dist/"
-	@echo "  make install-lint                - Install golint"
 
 
 # Test/check targets
@@ -73,12 +72,12 @@ vet:
 	$(GO) vet ./...
 
 lint:
-	which golint || $(GO) get -u golang.org/x/lint/golint
-	$(GO) list ./... | grep -v /vendor/ | xargs -L1 golint -set_exit_status
+	which golangci-lint || $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	golangci-lint run
 
 staticcheck: .PHONY
 	rm -rf build/staticcheck
-	which staticcheck || go get honnef.co/go/tools/cmd/staticcheck
+	which staticcheck || $(GO) install honnef.co/go/tools/cmd/staticcheck@latest
 	mkdir -p build/staticcheck
 	ln -s "$(GO)" build/staticcheck/go
 	PATH="$(PWD)/build/staticcheck:$(PATH)" staticcheck ./...

--- a/README.md
+++ b/README.md
@@ -275,6 +275,21 @@ make build-simple
 To build releases, I use [GoReleaser](https://goreleaser.com/). If you have that installed, you can run `make build` or
 `make build-snapshot`.
 
+## Development
+
+This project uses Go's standard tooling along with
+[golangci-lint](https://github.com/golangci/golangci-lint) and
+[staticcheck](https://staticcheck.io/) for linting and static analysis.
+
+```bash
+make fmt          # go fmt
+make vet          # go vet
+make lint         # golangci-lint
+make staticcheck  # staticcheck
+```
+
+Run `make check` to execute tests and all linters.
+
 ## Contributing
 I welcome any and all contributions. Just create a PR or an issue, or talk to me [on Slack](https://gophers.slack.com/archives/C02ABHKDCN7).
 


### PR DESCRIPTION
## Summary
- use `golangci-lint` instead of deprecated `golint`
- install linters with `go install`
- add README section documenting fmt/vet/lint workflow

## Testing
- `go fmt ./...`
- `go test ./... -count=1` *(hangs, aborted)*
- `make vet`
- `make lint` *(fails: errcheck issues)
- `make staticcheck` *(fails: SA1019)*

------
https://chatgpt.com/codex/tasks/task_e_68901aabf28c8325925c9200ab67669b