### PR TITLE
ci: add security scanning workflow

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,101 @@
+name: security
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck -format sarif ./... > govulncheck.sarif
+      - name: Upload results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: govulncheck.sarif
+
+  gosec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Run gosec
+        run: gosec -fmt sarif -out gosec.sarif ./...
+      - name: Upload results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: gosec.sarif
+
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+      - name: Check licenses
+        run: go-licenses check ./...
+      - name: Generate license report
+        run: go-licenses report ./... > license-report.csv
+      - name: Upload license report
+        uses: actions/upload-artifact@v4
+        with:
+          name: license-report
+          path: license-report.csv
+
+  container-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build production image
+        run: docker build -t replbot -f Dockerfile .
+      - name: Build test image
+        run: docker build -t replbot-test -f Dockerfile.test .
+      - name: Scan production image
+        uses: aquasecurity/trivy-action@v0.20.0
+        with:
+          image-ref: replbot
+          format: sarif
+          output: trivy-prod.sarif
+          exit-code: '1'
+      - name: Upload production scan results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-prod.sarif
+      - name: Scan test image
+        uses: aquasecurity/trivy-action@v0.20.0
+        with:
+          image-ref: replbot-test
+          format: sarif
+          output: trivy-test.sarif
+          exit-code: '1'
+      - name: Upload test scan results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-test.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository contains the Go sources for REPLbot.
 - Format Go code with `go fmt` (or `make fmt`) before committing.
 - Run unit tests with `go test ./...`. Many tests need `tmux`, `vim`, `asciinema`, and `ttyd`; they can be installed the same way as in `.github/workflows/test.yaml`.
 - For a full suite of checks including vetting and linting, run `make check`.
+- Security checks run via `.github/workflows/security.yaml` and include `govulncheck`, `gosec`, dependency license validation, and container image scans with Trivy. When changing dependencies or Dockerfiles, ensure these tools pass locally.
 
 ## Commit Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Release](https://img.shields.io/github/release/binwiederhier/replbot.svg?color=success&style=flat-square)](https://github.com/binwiederhier/replbot/releases/latest)
 [![Go Reference](https://pkg.go.dev/badge/heckel.io/replbot.svg)](https://pkg.go.dev/heckel.io/replbot)
 [![Tests](https://github.com/binwiederhier/replbot/workflows/test/badge.svg)](https://github.com/binwiederhier/replbot/actions)
+[![Security](https://github.com/binwiederhier/replbot/actions/workflows/security.yaml/badge.svg)](https://github.com/binwiederhier/replbot/actions/workflows/security.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/binwiederhier/replbot)](https://goreportcard.com/report/github.com/binwiederhier/replbot)
 [![codecov](https://codecov.io/gh/binwiederhier/replbot/branch/master/graph/badge.svg?token=bdrFZttMsk)](https://codecov.io/gh/binwiederhier/replbot)
 [![Slack channel](https://img.shields.io/badge/slack-@gophers/binwiederhier-success.svg?logo=slack)](https://gophers.slack.com/archives/C01JMTPGF2Q)


### PR DESCRIPTION
## Summary
- add daily security scanning workflow with govulncheck, gosec, license checks and container scans
- document security checks and add badge to README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68901e7efe8883259bb90fc16cdf07b3