### PR TITLE
Add app-token CLI flag for Slack Socket Mode

### DIFF
--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -308,7 +308,7 @@ func createConfig(t *testing.T) *config.Config {
 			t.Fatal(err)
 		}
 	}
-	conf := config.New("mem")
+	conf := config.New("mem", "")
 	conf.RefreshInterval = 30 * time.Millisecond
 	conf.ScriptDir = tempDir
 	return conf

--- a/bot/ratelimit_test.go
+++ b/bot/ratelimit_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRateLimiterAllowAndCleanup(t *testing.T) {
-	conf := config.New("mem")
+	conf := config.New("mem", "")
 	conf.MessageRateLimit = config.RateLimit{Requests: 1, Burst: 1, Interval: time.Second}
 	conf.RateLimitCleanupInterval = 50 * time.Millisecond
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -22,6 +23,7 @@ func New() *cli.App {
 		&cli.StringFlag{Name: "config", Aliases: []string{"c"}, EnvVars: []string{"REPLBOT_CONFIG_FILE"}, Value: "/etc/replbot/config.yml", DefaultText: "/etc/replbot/config.yml", Usage: "config file"},
 		&cli.BoolFlag{Name: "debug", EnvVars: []string{"REPLBOT_DEBUG"}, Value: false, Usage: "enable debugging output"},
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "bot-token", Aliases: []string{"t"}, EnvVars: []string{"REPLBOT_BOT_TOKEN"}, DefaultText: "none", Usage: "bot token"}),
+		altsrc.NewStringFlag(&cli.StringFlag{Name: "app-token", EnvVars: []string{"SLACK_APP_TOKEN"}, Usage: "Slack app-level token (Socket Mode)", Required: false}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "script-dir", Aliases: []string{"d"}, EnvVars: []string{"REPLBOT_SCRIPT_DIR"}, Value: "/etc/replbot/script.d", DefaultText: "/etc/replbot/script.d", Usage: "script directory"}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{Name: "idle-timeout", Aliases: []string{"T"}, EnvVars: []string{"REPLBOT_IDLE_TIMEOUT"}, Value: config.DefaultIdleTimeout, Usage: "timeout after which sessions are ended"}),
 		altsrc.NewIntFlag(&cli.IntFlag{Name: "max-total-sessions", Aliases: []string{"S"}, EnvVars: []string{"REPLBOT_MAX_TOTAL_SESSIONS"}, Value: config.DefaultMaxTotalSessions, Usage: "max number of concurrent total sessions"}),
@@ -65,6 +67,7 @@ func execRun(c *cli.Context) error {
 
 	// Read all the options
 	token := c.String("bot-token")
+	appToken := c.String("app-token")
 	scriptDir := c.String("script-dir")
 	timeout := c.Duration("idle-timeout")
 	maxTotalSessions := c.Int("max-total-sessions")
@@ -110,6 +113,9 @@ func execRun(c *cli.Context) error {
 	if token == "" || token == "MUST_BE_SET" {
 		vErrs = append(vErrs, bot.NewConfigError("MISSING_BOT_TOKEN", "missing bot token, pass --bot-token, set REPLBOT_BOT_TOKEN env variable or bot-token config option", nil))
 	}
+	if strings.HasPrefix(token, "xoxb-") && appToken == "" {
+		vErrs = append(vErrs, bot.NewConfigError("MISSING_APP_TOKEN", "missing Slack app-level token, pass --app-token or set SLACK_APP_TOKEN env variable", nil))
+	}
 	if _, err := os.Stat(scriptDir); err != nil {
 		vErrs = append(vErrs, bot.NewConfigError("SCRIPT_DIR_NOT_FOUND", fmt.Sprintf("cannot find REPL directory %s, set --script-dir, set REPLBOT_SCRIPT_DIR env variable, or script-dir config option", scriptDir), err))
 	} else if entries, err := os.ReadDir(scriptDir); err != nil || len(entries) == 0 {
@@ -152,7 +158,7 @@ func execRun(c *cli.Context) error {
 	}
 
 	// Create main bot
-	conf := config.New(token)
+	conf := config.New(token, appToken)
 	conf.ScriptDir = scriptDir
 	conf.IdleTimeout = timeout
 	conf.MaxTotalSessions = maxTotalSessions

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type RateLimit struct {
 // Config is the main config struct for the application. Use New to instantiate a default config struct.
 type Config struct {
 	Token                    string
+	AppToken                 string
 	ScriptDir                string
 	IdleTimeout              time.Duration
 	MaxTotalSessions         int
@@ -68,9 +69,10 @@ type Config struct {
 }
 
 // New instantiates a default new config
-func New(token string) *Config {
+func New(token, appToken string) *Config {
 	return &Config{
 		Token:                    token,
+		AppToken:                 appToken,
 		IdleTimeout:              DefaultIdleTimeout,
 		MaxTotalSessions:         DefaultMaxTotalSessions,
 		MaxUserSessions:          DefaultMaxUserSessions,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,7 @@ func TestNew(t *testing.T) {
 	if err := os.WriteFile(script2, []byte{}, 0700); err != nil {
 		t.Fatal(err)
 	}
-	conf := New("xoxb-slack-token")
+	conf := New("xoxb-slack-token", "")
 	conf.ScriptDir = dir
 	assert.Equal(t, Slack, conf.Platform())
 	assert.ElementsMatch(t, []string{"script1", "script2"}, conf.Scripts())
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewDiscordShareHost(t *testing.T) {
-	conf := New("not-slack")
+	conf := New("not-slack", "")
 	conf.ShareHost = "localhost:2586"
 	conf.ScriptDir = "/does-not-exist"
 	assert.Equal(t, Discord, conf.Platform())


### PR DESCRIPTION
## Summary
- add `--app-token` CLI flag and env var to supply Slack app-level token
- validate Slack bot tokens require accompanying app token
- pass both bot token and app token to configuration

## Testing
- `go test ./...` *(fails: cmd/app.go:161:28: too many arguments in call to config.New, want (string))*


------
https://chatgpt.com/codex/tasks/task_e_6890385b4928832580f93073463cf190