### PR TITLE
Add Slack app token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ API. To create a classic app and acquire a Slack bot token, follow these steps:
 2. In the "App Home" section, add a "Legacy bot user"
 3. In the "OAuth & Permissions" section, click "Install to Workspace" (_this may require workspace admin approval_)
 4. Copy the "Bot User OAuth Token" starting with "xoxb-..."
+5. Create an "App-Level Token" with the "connections:write" scope for Socket Mode and copy the token starting with "xapp-..."
 
 **Creating a REPLbot Discord app**:   
 1. Create a [Discord app](https://discord.com/developers/applications) 

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -308,7 +308,7 @@ func createConfig(t *testing.T) *config.Config {
 			t.Fatal(err)
 		}
 	}
-	conf := config.New("mem")
+	conf := config.New("mem", "")
 	conf.RefreshInterval = 30 * time.Millisecond
 	conf.ScriptDir = tempDir
 	return conf

--- a/bot/ratelimit_test.go
+++ b/bot/ratelimit_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRateLimiterAllowAndCleanup(t *testing.T) {
-	conf := config.New("mem")
+	conf := config.New("mem", "")
 	conf.MessageRateLimit = config.RateLimit{Requests: 1, Burst: 1, Interval: time.Second}
 	conf.RateLimitCleanupInterval = 50 * time.Millisecond
 

--- a/bot/session.go
+++ b/bot/session.go
@@ -550,7 +550,7 @@ func (s *session) sessionStartedMessage() string {
 func (s *session) maybeTrimWindow(window string) string {
 	switch s.conf.windowMode {
 	case config.Full:
-		if s.conf.global.Platform() == config.Discord {
+		if p, _ := s.conf.global.Platform(); p == config.Discord {
 			return expandWindow(window)
 		}
 		return window
@@ -762,7 +762,8 @@ func (s *session) maybeSendMessageLengthWarning(size *config.Size) error {
 }
 
 func (s *session) shouldWarnMessageLength(size *config.Size) bool {
-	return s.conf.global.Platform() == config.Discord && (size == config.Medium || size == config.Large)
+	p, _ := s.conf.global.Platform()
+	return p == config.Discord && (size == config.Medium || size == config.Large)
 }
 
 func (s *session) handlePassthrough(input string) error {

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -22,6 +23,7 @@ func New() *cli.App {
 		&cli.StringFlag{Name: "config", Aliases: []string{"c"}, EnvVars: []string{"REPLBOT_CONFIG_FILE"}, Value: "/etc/replbot/config.yml", DefaultText: "/etc/replbot/config.yml", Usage: "config file"},
 		&cli.BoolFlag{Name: "debug", EnvVars: []string{"REPLBOT_DEBUG"}, Value: false, Usage: "enable debugging output"},
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "bot-token", Aliases: []string{"t"}, EnvVars: []string{"REPLBOT_BOT_TOKEN"}, DefaultText: "none", Usage: "bot token"}),
+		altsrc.NewStringFlag(&cli.StringFlag{Name: "app-token", Aliases: []string{"p"}, EnvVars: []string{"REPLBOT_APP_TOKEN"}, DefaultText: "none", Usage: "slack app token"}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "script-dir", Aliases: []string{"d"}, EnvVars: []string{"REPLBOT_SCRIPT_DIR"}, Value: "/etc/replbot/script.d", DefaultText: "/etc/replbot/script.d", Usage: "script directory"}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{Name: "idle-timeout", Aliases: []string{"T"}, EnvVars: []string{"REPLBOT_IDLE_TIMEOUT"}, Value: config.DefaultIdleTimeout, Usage: "timeout after which sessions are ended"}),
 		altsrc.NewIntFlag(&cli.IntFlag{Name: "max-total-sessions", Aliases: []string{"S"}, EnvVars: []string{"REPLBOT_MAX_TOTAL_SESSIONS"}, Value: config.DefaultMaxTotalSessions, Usage: "max number of concurrent total sessions"}),
@@ -65,6 +67,7 @@ func execRun(c *cli.Context) error {
 
 	// Read all the options
 	token := c.String("bot-token")
+	appToken := c.String("app-token")
 	scriptDir := c.String("script-dir")
 	timeout := c.Duration("idle-timeout")
 	maxTotalSessions := c.Int("max-total-sessions")
@@ -110,6 +113,9 @@ func execRun(c *cli.Context) error {
 	if token == "" || token == "MUST_BE_SET" {
 		vErrs = append(vErrs, bot.NewConfigError("MISSING_BOT_TOKEN", "missing bot token, pass --bot-token, set REPLBOT_BOT_TOKEN env variable or bot-token config option", nil))
 	}
+	if strings.HasPrefix(token, "xoxb-") && !strings.HasPrefix(appToken, "xapp-") {
+		vErrs = append(vErrs, bot.NewConfigError("MISSING_APP_TOKEN", "missing app token, pass --app-token, set REPLBOT_APP_TOKEN env variable or app-token config option", nil))
+	}
 	if _, err := os.Stat(scriptDir); err != nil {
 		vErrs = append(vErrs, bot.NewConfigError("SCRIPT_DIR_NOT_FOUND", fmt.Sprintf("cannot find REPL directory %s, set --script-dir, set REPLBOT_SCRIPT_DIR env variable, or script-dir config option", scriptDir), err))
 	} else if entries, err := os.ReadDir(scriptDir); err != nil || len(entries) == 0 {
@@ -152,7 +158,7 @@ func execRun(c *cli.Context) error {
 	}
 
 	// Create main bot
-	conf := config.New(token)
+	conf := config.New(token, appToken)
 	conf.ScriptDir = scriptDir
 	conf.IdleTimeout = timeout
 	conf.MaxTotalSessions = maxTotalSessions

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type RateLimit struct {
 // Config is the main config struct for the application. Use New to instantiate a default config struct.
 type Config struct {
 	Token                    string
+	AppToken                 string
 	ScriptDir                string
 	IdleTimeout              time.Duration
 	MaxTotalSessions         int
@@ -68,9 +69,10 @@ type Config struct {
 }
 
 // New instantiates a default new config
-func New(token string) *Config {
+func New(token string, appToken string) *Config {
 	return &Config{
 		Token:                    token,
+		AppToken:                 appToken,
 		IdleTimeout:              DefaultIdleTimeout,
 		MaxTotalSessions:         DefaultMaxTotalSessions,
 		MaxUserSessions:          DefaultMaxUserSessions,
@@ -87,13 +89,20 @@ func New(token string) *Config {
 }
 
 // Platform returns the target connection type, based on the token
-func (c *Config) Platform() Platform {
+func (c *Config) Platform() (Platform, error) {
 	if strings.HasPrefix(c.Token, "mem") {
-		return Mem
-	} else if strings.HasPrefix(c.Token, "xoxb-") {
-		return Slack
+		return Mem, nil
 	}
-	return Discord
+	if strings.HasPrefix(c.Token, "xoxb-") || strings.HasPrefix(c.AppToken, "xapp-") {
+		if !strings.HasPrefix(c.AppToken, "xapp-") {
+			return "", NewConfigError("INVALID_SLACK_APP_TOKEN", "slack app token must start with 'xapp-'", nil)
+		}
+		if !strings.HasPrefix(c.Token, "xoxb-") {
+			return "", NewConfigError("INVALID_SLACK_BOT_TOKEN", "slack bot token must start with 'xoxb-'", nil)
+		}
+		return Slack, nil
+	}
+	return Discord, nil
 }
 
 // ShareEnabled returns true if the share features is enabled

--- a/config/config.yml
+++ b/config/config.yml
@@ -26,6 +26,15 @@
 #
 bot-token: MUST_BE_SET
 
+# Slack App token used for socket mode connections.
+# Required for Slack connections. Must start with "xapp-".
+#
+# Format:    long cryptic string starting with xapp-
+# Default:   None
+# Required:  For Slack
+#
+app-token: ""
+
 # Directory containing your REPL scripts. REPLbot ships with a bunch of default scripts. Be sure
 # to check them out and add/remove scripts as you like.
 #

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,9 +17,11 @@ func TestNew(t *testing.T) {
 	if err := os.WriteFile(script2, []byte{}, 0700); err != nil {
 		t.Fatal(err)
 	}
-	conf := New("xoxb-slack-token")
+	conf := New("xoxb-slack-token", "xapp-slack-app-token")
 	conf.ScriptDir = dir
-	assert.Equal(t, Slack, conf.Platform())
+	platform, err := conf.Platform()
+	assert.NoError(t, err)
+	assert.Equal(t, Slack, platform)
 	assert.ElementsMatch(t, []string{"script1", "script2"}, conf.Scripts())
 	assert.False(t, conf.ShareEnabled())
 	assert.Empty(t, conf.Script("does-not-exist"))
@@ -28,10 +30,12 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewDiscordShareHost(t *testing.T) {
-	conf := New("not-slack")
+	conf := New("not-slack", "")
 	conf.ShareHost = "localhost:2586"
 	conf.ScriptDir = "/does-not-exist"
-	assert.Equal(t, Discord, conf.Platform())
+	platform, err := conf.Platform()
+	assert.NoError(t, err)
+	assert.Equal(t, Discord, platform)
 	assert.Empty(t, conf.Scripts())
 	assert.True(t, conf.ShareEnabled())
 }

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -82,3 +83,31 @@ const (
 	CursorOff = time.Duration(0)
 	CursorOn  = time.Duration(1)
 )
+
+// ConfigError represents configuration errors.
+type ConfigError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+// Error implements the error interface.
+func (e *ConfigError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+	}
+	return e.Message
+}
+
+// Unwrap returns the underlying cause.
+func (e *ConfigError) Unwrap() error {
+	return e.Cause
+}
+
+// NewConfigError creates a new ConfigError.
+func NewConfigError(code, message string, cause error) *ConfigError {
+	return &ConfigError{Code: code, Message: message, Cause: cause}
+}


### PR DESCRIPTION
## Summary
- add Slack app token to configuration and validate bot/app tokens
- expose `--app-token` flag and sample config entry
- document obtaining an app-level token for Socket Mode

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890381b35c48325ac08a9962c41492a