### PR TITLE
feat: maintain Slack online presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   --debug                   enable debugging output
   --bot-token, -t           bot token (env: REPLBOT_BOT_TOKEN)
   --app-token, -p           Slack app-level token for Socket Mode (env: SLACK_APP_TOKEN)
+  --user-token, -u          Slack user token to set presence (env: SLACK_USER_TOKEN)
   --script-dir, -d          script directory (default: /etc/replbot/script.d)
   --idle-timeout, -T        timeout after which sessions are ended
   --max-total-sessions, -S  max number of concurrent total sessions
@@ -222,14 +223,14 @@ REPLbot uses Slack's modern Socket Mode API for real-time communication. To crea
 5. In the "Bot" section, copy the token and paste it here
 
 **Installing `replbot`**:   
-1. Make sure `tmux` and probably also `docker` are installed. Then install REPLbot using any of the methods below. 
+1. Make sure `tmux` and probably also `docker` are installed. Then install REPLbot using any of the methods below.
 2. Configure your bot tokens using one of these methods:
-   - **Config file**: Edit `/etc/replbot/config.yml` and set `bot-token` and `app-token`
-   - **Environment variables**: Set `REPLBOT_BOT_TOKEN` and `SLACK_APP_TOKEN`
-   - **.env file**: Create a `.env` file with `REPLBOT_BOT_TOKEN=` and `SLACK_APP_TOKEN=` entries
-   - **Command line**: Use `--bot-token` and `--app-token` flags
-   
-   For Slack: Set both `bot-token` (xoxb-...) and `app-token` (xapp-...)
+   - **Config file**: Edit `/etc/replbot/config.yml` and set `bot-token`, `app-token` and optionally `user-token`
+   - **Environment variables**: Set `REPLBOT_BOT_TOKEN`, `SLACK_APP_TOKEN` and optionally `SLACK_USER_TOKEN`
+   - **.env file**: Create a `.env` file with `REPLBOT_BOT_TOKEN=`, `SLACK_APP_TOKEN=` and `SLACK_USER_TOKEN=` entries
+   - **Command line**: Use `--bot-token`, `--app-token` and optionally `--user-token` (`-u`) flags
+
+   For Slack: Set `bot-token` (xoxb-...) and `app-token` (xapp-...). If you want the bot to appear online, also provide `user-token` (xoxp-...) with the `users:write` scope.
    For Discord: Set only `bot-token`
    REPLbot will automatically detect the platform based on token format
 3. Review the scripts in `/etc/replbot/script.d`, and make sure that you have Docker installed if you'd like to use them.
@@ -273,7 +274,8 @@ sudo mkdir /etc/replbot
 sudo cp -a replbot-0.6.4/config/{script.d,config.yml} /etc/replbot
 vi /etc/replbot/config.yml
   # Configure at least "bot-token" and "app-token" (for Slack)
-  # Or create a .env file with REPLBOT_BOT_TOKEN= and SLACK_APP_TOKEN= entries
+  # Optionally set "user-token" if you want the bot to appear online
+  # Or create a .env file with REPLBOT_BOT_TOKEN=, SLACK_APP_TOKEN= and SLACK_USER_TOKEN= entries
   # To support web terminal, set "web-host" (e.g. to localhost:31001)
   # To support sharing, set "share-host" (e.g. to localhost:31002)
   

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -585,7 +585,7 @@ func (b *Bot) sshReversePortForwardingCallback(ctx ssh.Context, host string, por
 	defer func() {
 		if !allow {
 			slog.Info("rejecting connection", "remote", conn.RemoteAddr())
-			conn.Close()
+			_ = conn.Close()
 		}
 	}()
 	if port < 1024 || (host != "localhost" && host != "127.0.0.1") {

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -216,7 +216,9 @@ func TestBotBashWebTerminal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)

--- a/bot/conn_slack.go
+++ b/bot/conn_slack.go
@@ -37,10 +37,14 @@ const (
 
 	// Event channel buffer size for better performance
 	eventChannelBuffer = 100
+
+	// Interval for keeping Slack presence active
+	presencePingInterval = 5 * time.Minute
 )
 
 type slackConn struct {
 	client       *slack.Client
+	userClient   *slack.Client
 	socketClient *socketmode.Client
 	cancel       context.CancelFunc
 	userID       string
@@ -92,6 +96,11 @@ func (c *slackConn) Connect(ctx context.Context) (<-chan event, error) {
 		return c.monitorConnection(gctx, eventChan)
 	})
 
+	// Start presence keep-alive goroutine
+	g.Go(func() error {
+		return c.keepPresence(gctx)
+	})
+
 	// Handle errgroup errors in a separate goroutine
 	go func() {
 		if err := g.Wait(); err != nil && ctx.Err() == nil {
@@ -116,8 +125,14 @@ func (c *slackConn) initializeConnection(ctx context.Context) error {
 	socketClient := socketmode.New(client,
 		socketmode.OptionDebug(c.config.Debug))
 
+	var userClient *slack.Client
+	if c.config.UserToken != "" {
+		userClient = slack.New(c.config.UserToken, slack.OptionDebug(c.config.Debug))
+	}
+
 	c.mu.Lock()
 	c.client = client
+	c.userClient = userClient
 	c.socketClient = socketClient
 	c.connected = false
 	c.reconnectCount = 0
@@ -260,6 +275,38 @@ func (c *slackConn) monitorConnection(ctx context.Context, eventChan chan<- even
 	}
 }
 
+// keepPresence sets and refreshes user presence while connected
+func (c *slackConn) keepPresence(ctx context.Context) error {
+	if c.userClient == nil {
+		return nil
+	}
+
+	// Set initial presence
+	if err := c.userClient.SetUserPresence("auto"); err != nil {
+		slog.Error("failed to set Slack presence", "error", err)
+	}
+	if err := c.userClient.SetUserAsActive(); err != nil {
+		slog.Error("failed to set Slack active", "error", err)
+	}
+
+	ticker := time.NewTicker(presencePingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if err := c.userClient.SetUserPresence("away"); err != nil {
+				slog.Error("failed to set Slack away", "error", err)
+			}
+			return nil
+		case <-ticker.C:
+			if err := c.userClient.SetUserAsActive(); err != nil {
+				slog.Warn("failed to refresh Slack presence", "error", err)
+			}
+		}
+	}
+}
+
 // reconnect attempts to reconnect with exponential backoff
 func (c *slackConn) reconnect(ctx context.Context) error {
 	c.mu.Lock()
@@ -383,6 +430,11 @@ func (c *slackConn) Archive(_ *channelID) error {
 func (c *slackConn) Close() error {
 	if c.cancel != nil {
 		c.cancel()
+	}
+	if c.userClient != nil {
+		if err := c.userClient.SetUserPresence("away"); err != nil {
+			slog.Error("failed to set Slack away", "error", err)
+		}
 	}
 	return nil
 }

--- a/bot/session.go
+++ b/bot/session.go
@@ -644,8 +644,8 @@ func (s *session) createRecordingArchive(filename string) (*os.File, error) {
 	recordingFile := s.tmux.RecordingFile()
 	asciinemaFile := s.asciinemaFile()
 	defer func() {
-		os.Remove(recordingFile)
-		os.Remove(asciinemaFile)
+		_ = os.Remove(recordingFile)
+		_ = os.Remove(asciinemaFile)
 	}()
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
@@ -718,8 +718,10 @@ func (s *session) sendExitedMessageWithRecording() error {
 		return err
 	}
 	defer func() {
-		file.Close()
-		os.Remove(filename)
+		if err := file.Close(); err != nil {
+			slog.Warn("failed to close recording file", "error", err)
+		}
+		_ = os.Remove(filename)
 	}()
 	message := sessionExitedWithRecordingMessage
 	if url != "" {
@@ -1034,17 +1036,23 @@ func (s *session) maybeUploadAsciinemaRecording() (url string, expiry string, er
 func (s *session) maybePatchAsciinemaRecordingFile() error {
 	replayFile := s.asciinemaFile()
 	tempReplayFile := fmt.Sprintf("%s.tmp", replayFile)
-	defer os.Remove(tempReplayFile)
+	defer func() {
+		_ = os.Remove(tempReplayFile)
+	}()
 	in, err := os.Open(s.asciinemaFile())
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() {
+		_ = in.Close()
+	}()
 	out, err := os.OpenFile(tempReplayFile, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+	}()
 	rd := bufio.NewReader(in)
 	header, err := rd.ReadString('\n')
 	if err != nil {

--- a/bot/session_test.go
+++ b/bot/session_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestSessionCustomShell(t *testing.T) {
 	sess, conn := createSession(t, "enter-name")
-	defer sess.ForceClose()
+	defer func() {
+		_ = sess.ForceClose()
+	}()
 	assert.True(t, conn.MessageContainsWait("1", "REPL session started, @phil"))
 	assert.True(t, conn.MessageContainsWait("2", "Enter name:"))
 
@@ -31,7 +33,9 @@ func TestSessionCustomShell(t *testing.T) {
 
 func TestBashShell(t *testing.T) {
 	sess, conn := createSession(t, "bash")
-	defer sess.ForceClose()
+	defer func() {
+		_ = sess.ForceClose()
+	}()
 
 	dir := t.TempDir()
 	sess.UserInput("phil", "cd "+dir)
@@ -94,7 +98,9 @@ func TestBashShell(t *testing.T) {
 
 func TestSessionCommands(t *testing.T) {
 	sess, conn := createSession(t, "bash")
-	defer sess.ForceClose()
+	defer func() {
+		_ = sess.ForceClose()
+	}()
 
 	dir := t.TempDir()
 	sess.UserInput("phil", "!e echo \"Phil\\bL\\nwas here\\ris here\"\\n")
@@ -121,7 +127,9 @@ func TestSessionCommands(t *testing.T) {
 
 func TestWriteShareClientScriptNotShare(t *testing.T) {
 	sess, _ := createSession(t, "bash")
-	defer sess.ForceClose()
+	defer func() {
+		_ = sess.ForceClose()
+	}()
 	err := sess.WriteShareClientScript(io.Discard)
 	var se *SessionError
 	assert.True(t, errors.As(err, &se))

--- a/bot/util.go
+++ b/bot/util.go
@@ -120,7 +120,9 @@ func zipAppendFile(zw *zip.Writer, name string, filename string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	w, err := zw.Create(name)
 	if err != nil {
 		return err

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -24,6 +24,7 @@ func New() *cli.App {
 		&cli.BoolFlag{Name: "debug", EnvVars: []string{"REPLBOT_DEBUG"}, Value: false, Usage: "enable debugging output"},
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "bot-token", Aliases: []string{"t"}, EnvVars: []string{"REPLBOT_BOT_TOKEN"}, DefaultText: "none", Usage: "bot token"}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "app-token", Aliases: []string{"p"}, EnvVars: []string{"SLACK_APP_TOKEN"}, Usage: "Slack app-level token (Socket Mode)", Required: false}),
+		altsrc.NewStringFlag(&cli.StringFlag{Name: "user-token", Aliases: []string{"u"}, EnvVars: []string{"SLACK_USER_TOKEN"}, Usage: "Slack user token to set presence"}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "script-dir", Aliases: []string{"d"}, EnvVars: []string{"REPLBOT_SCRIPT_DIR"}, Value: "/etc/replbot/script.d", DefaultText: "/etc/replbot/script.d", Usage: "script directory"}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{Name: "idle-timeout", Aliases: []string{"T"}, EnvVars: []string{"REPLBOT_IDLE_TIMEOUT"}, Value: config.DefaultIdleTimeout, Usage: "timeout after which sessions are ended"}),
 		altsrc.NewIntFlag(&cli.IntFlag{Name: "max-total-sessions", Aliases: []string{"S"}, EnvVars: []string{"REPLBOT_MAX_TOTAL_SESSIONS"}, Value: config.DefaultMaxTotalSessions, Usage: "max number of concurrent total sessions"}),
@@ -68,6 +69,7 @@ func execRun(c *cli.Context) error {
 	// Read all the options
 	token := c.String("bot-token")
 	appToken := c.String("app-token")
+	userToken := c.String("user-token")
 	scriptDir := c.String("script-dir")
 	timeout := c.Duration("idle-timeout")
 	maxTotalSessions := c.Int("max-total-sessions")
@@ -159,6 +161,7 @@ func execRun(c *cli.Context) error {
 
 	// Create main bot
 	conf := config.New(token, appToken)
+	conf.UserToken = userToken
 	conf.ScriptDir = scriptDir
 	conf.IdleTimeout = timeout
 	conf.MaxTotalSessions = maxTotalSessions

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type RateLimit struct {
 type Config struct {
 	Token                    string
 	AppToken                 string
+	UserToken                string
 	ScriptDir                string
 	IdleTimeout              time.Duration
 	MaxTotalSessions         int

--- a/config/config.yml
+++ b/config/config.yml
@@ -39,6 +39,15 @@ bot-token: MUST_BE_SET
 #
 app-token: ""
 
+# Slack user token used to set the bot's presence to online.
+# Optional; if set, must start with "xoxp-" and have the "users:write" scope.
+#
+# Format:    long cryptic string starting with xoxp-
+# Default:   None
+# Required:  No
+#
+user-token: ""
+
 # Directory containing your REPL scripts. REPLbot ships with a bunch of default scripts. Be sure
 # to check them out and add/remove scripts as you like.
 #

--- a/util/tmux.go
+++ b/util/tmux.go
@@ -51,13 +51,13 @@ func NewTmux(id string, width, height int) *Tmux {
 
 // Start starts the tmux using the given command and arguments
 func (s *Tmux) Start(env map[string]string, command ...string) error {
-	defer os.Remove(s.scriptFile())
-	defer os.Remove(s.launchScriptFile())
+	defer func() { _ = os.Remove(s.scriptFile()) }()
+	defer func() { _ = os.Remove(s.launchScriptFile()) }()
 	script, err := os.OpenFile(s.scriptFile(), os.O_CREATE|os.O_WRONLY, 0700)
 	if err != nil {
 		return err
 	}
-	defer script.Close()
+	defer func() { _ = script.Close() }()
 	params := &tmuxScriptParams{
 		MainID:             s.mainID(),
 		FrameID:            s.frameID(),
@@ -86,7 +86,7 @@ func (s *Tmux) Active() bool {
 
 // Paste pastes the input into the tmux, as if the user entered it
 func (s *Tmux) Paste(input string) error {
-	defer os.Remove(s.bufferFile())
+	defer func() { _ = os.Remove(s.bufferFile()) }()
 	if err := os.WriteFile(s.bufferFile(), []byte(input), 0600); err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -67,7 +67,7 @@ func RandomPort() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 	_, p, err := net.SplitHostPort(listener.Addr().String())
 	if err != nil {
 		return 0, err
@@ -148,8 +148,8 @@ func GenerateSSHKeyPair() (pair *SSHKeyPair, err error) {
 	}
 	pubKeyFile := privKeyFile + ".pub"
 	defer func() {
-		os.Remove(privKeyFile)
-		os.Remove(pubKeyFile)
+		_ = os.Remove(privKeyFile)
+		_ = os.Remove(pubKeyFile)
 	}()
 	if err := Run("ssh-keygen", "-t", "rsa", "-f", privKeyFile, "-q", "-N", ""); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- allow providing a Slack user token for presence updates
- keep Slack user presence active while bot runs and mark it away on shutdown
- document `SLACK_USER_TOKEN` option and CLI flag

## Testing
- `make fmt`
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891632a6be883259dbc489f9911816e