### PR TITLE
Require Slack user token

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Options:
   --debug                   enable debugging output
   --bot-token, -t           bot token (env: REPLBOT_BOT_TOKEN)
   --app-token, -p           Slack app-level token for Socket Mode (env: SLACK_APP_TOKEN)
-  --user-token, -u          Slack user token to set presence (env: SLACK_USER_TOKEN)
+  --user-token, -u          Slack user token to set presence (env: SLACK_USER_TOKEN, required for Slack)
   --script-dir, -d          script directory (default: /etc/replbot/script.d)
   --idle-timeout, -T        timeout after which sessions are ended
   --max-total-sessions, -S  max number of concurrent total sessions
@@ -225,12 +225,12 @@ REPLbot uses Slack's modern Socket Mode API for real-time communication. To crea
 **Installing `replbot`**:   
 1. Make sure `tmux` and probably also `docker` are installed. Then install REPLbot using any of the methods below.
 2. Configure your bot tokens using one of these methods:
-   - **Config file**: Edit `/etc/replbot/config.yml` and set `bot-token`, `app-token` and optionally `user-token`
-   - **Environment variables**: Set `REPLBOT_BOT_TOKEN`, `SLACK_APP_TOKEN` and optionally `SLACK_USER_TOKEN`
+   - **Config file**: Edit `/etc/replbot/config.yml` and set `bot-token`, `app-token` and `user-token`
+   - **Environment variables**: Set `REPLBOT_BOT_TOKEN`, `SLACK_APP_TOKEN` and `SLACK_USER_TOKEN`
    - **.env file**: Create a `.env` file with `REPLBOT_BOT_TOKEN=`, `SLACK_APP_TOKEN=` and `SLACK_USER_TOKEN=` entries
-   - **Command line**: Use `--bot-token`, `--app-token` and optionally `--user-token` (`-u`) flags
+   - **Command line**: Use `--bot-token`, `--app-token` and `--user-token` (`-u`) flags
 
-   For Slack: Set `bot-token` (xoxb-...) and `app-token` (xapp-...). If you want the bot to appear online, also provide `user-token` (xoxp-...) with the `users:write` scope.
+   For Slack: Set `bot-token` (xoxb-...), `app-token` (xapp-...) and `user-token` (xoxp-...) with the `users:write` scope.
    For Discord: Set only `bot-token`
    REPLbot will automatically detect the platform based on token format
 3. Review the scripts in `/etc/replbot/script.d`, and make sure that you have Docker installed if you'd like to use them.
@@ -273,8 +273,7 @@ tar zxvf v0.6.4.tar.gz
 sudo mkdir /etc/replbot
 sudo cp -a replbot-0.6.4/config/{script.d,config.yml} /etc/replbot
 vi /etc/replbot/config.yml
-  # Configure at least "bot-token" and "app-token" (for Slack)
-  # Optionally set "user-token" if you want the bot to appear online
+  # Configure "bot-token", "app-token" and "user-token" (for Slack)
   # Or create a .env file with REPLBOT_BOT_TOKEN=, SLACK_APP_TOKEN= and SLACK_USER_TOKEN= entries
   # To support web terminal, set "web-host" (e.g. to localhost:31001)
   # To support sharing, set "share-host" (e.g. to localhost:31002)

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -24,7 +24,7 @@ func New() *cli.App {
 		&cli.BoolFlag{Name: "debug", EnvVars: []string{"REPLBOT_DEBUG"}, Value: false, Usage: "enable debugging output"},
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "bot-token", Aliases: []string{"t"}, EnvVars: []string{"REPLBOT_BOT_TOKEN"}, DefaultText: "none", Usage: "bot token"}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "app-token", Aliases: []string{"p"}, EnvVars: []string{"SLACK_APP_TOKEN"}, Usage: "Slack app-level token (Socket Mode)", Required: false}),
-		altsrc.NewStringFlag(&cli.StringFlag{Name: "user-token", Aliases: []string{"u"}, EnvVars: []string{"SLACK_USER_TOKEN"}, Usage: "Slack user token to set presence"}),
+		altsrc.NewStringFlag(&cli.StringFlag{Name: "user-token", Aliases: []string{"u"}, EnvVars: []string{"SLACK_USER_TOKEN"}, Usage: "Slack user token to set presence (required for Slack)"}),
 		altsrc.NewStringFlag(&cli.StringFlag{Name: "script-dir", Aliases: []string{"d"}, EnvVars: []string{"REPLBOT_SCRIPT_DIR"}, Value: "/etc/replbot/script.d", DefaultText: "/etc/replbot/script.d", Usage: "script directory"}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{Name: "idle-timeout", Aliases: []string{"T"}, EnvVars: []string{"REPLBOT_IDLE_TIMEOUT"}, Value: config.DefaultIdleTimeout, Usage: "timeout after which sessions are ended"}),
 		altsrc.NewIntFlag(&cli.IntFlag{Name: "max-total-sessions", Aliases: []string{"S"}, EnvVars: []string{"REPLBOT_MAX_TOTAL_SESSIONS"}, Value: config.DefaultMaxTotalSessions, Usage: "max number of concurrent total sessions"}),

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,9 @@ func (c *Config) Platform() (Platform, error) {
 		if !strings.HasPrefix(c.Token, "xoxb-") {
 			return "", NewConfigError("INVALID_SLACK_BOT_TOKEN", "slack bot token must start with 'xoxb-'", nil)
 		}
+		if !strings.HasPrefix(c.UserToken, "xoxp-") {
+			return "", NewConfigError("INVALID_SLACK_USER_TOKEN", "slack user token must start with 'xoxp-'", nil)
+		}
 		return Slack, nil
 	}
 	return Discord, nil

--- a/config/config.yml
+++ b/config/config.yml
@@ -40,11 +40,11 @@ bot-token: MUST_BE_SET
 app-token: ""
 
 # Slack user token used to set the bot's presence to online.
-# Optional; if set, must start with "xoxp-" and have the "users:write" scope.
+# Required for Slack connections. Must start with "xoxp-" and have the "users:write" scope.
 #
 # Format:    long cryptic string starting with xoxp-
 # Default:   None
-# Required:  No
+# Required:  For Slack
 #
 user-token: ""
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,3 +55,17 @@ func TestSlackUserTokenRequired(t *testing.T) {
 		t.Fatalf("expected ConfigError, got %T", err)
 	}
 }
+
+func TestSlackInvalidUserToken(t *testing.T) {
+	conf := confpkg.New("xoxb-slack-token", "xapp-slack-app-token")
+	conf.UserToken = "invalid-token"
+	_, err := conf.Platform()
+	assert.Error(t, err)
+	if cfgErr, ok := err.(*bot.ConfigError); ok {
+		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
+	} else if cfgErr, ok := err.(*confpkg.ConfigError); ok {
+		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
+	} else {
+		t.Fatalf("expected ConfigError, got %T", err)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,8 +2,7 @@ package config_test
 
 import (
 	"github.com/stretchr/testify/assert"
-	"heckel.io/replbot/bot"
-	confpkg "heckel.io/replbot/config"
+	"heckel.io/replbot/config"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,12 +18,12 @@ func TestNew(t *testing.T) {
 	if err := os.WriteFile(script2, []byte{}, 0700); err != nil {
 		t.Fatal(err)
 	}
-	conf := confpkg.New("xoxb-slack-token", "xapp-slack-app-token")
+	conf := config.New("xoxb-slack-token", "xapp-slack-app-token")
 	conf.UserToken = "xoxp-slack-user-token"
 	conf.ScriptDir = dir
 	platform, err := conf.Platform()
 	assert.NoError(t, err)
-	assert.Equal(t, confpkg.Slack, platform)
+	assert.Equal(t, config.Slack, platform)
 	assert.ElementsMatch(t, []string{"script1", "script2"}, conf.Scripts())
 	assert.False(t, conf.ShareEnabled())
 	assert.Empty(t, conf.Script("does-not-exist"))
@@ -33,23 +32,21 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewDiscordShareHost(t *testing.T) {
-	conf := confpkg.New("not-slack", "")
+	conf := config.New("not-slack", "")
 	conf.ShareHost = "localhost:2586"
 	conf.ScriptDir = "/does-not-exist"
 	platform, err := conf.Platform()
 	assert.NoError(t, err)
-	assert.Equal(t, confpkg.Discord, platform)
+	assert.Equal(t, config.Discord, platform)
 	assert.Empty(t, conf.Scripts())
 	assert.True(t, conf.ShareEnabled())
 }
 
 func TestSlackUserTokenRequired(t *testing.T) {
-	conf := confpkg.New("xoxb-slack-token", "xapp-slack-app-token")
+	conf := config.New("xoxb-slack-token", "xapp-slack-app-token")
 	_, err := conf.Platform()
 	assert.Error(t, err)
-	if cfgErr, ok := err.(*bot.ConfigError); ok {
-		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
-	} else if cfgErr, ok := err.(*confpkg.ConfigError); ok {
+	if cfgErr, ok := err.(*config.ConfigError); ok {
 		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
 	} else {
 		t.Fatalf("expected ConfigError, got %T", err)
@@ -57,13 +54,11 @@ func TestSlackUserTokenRequired(t *testing.T) {
 }
 
 func TestSlackInvalidUserToken(t *testing.T) {
-	conf := confpkg.New("xoxb-slack-token", "xapp-slack-app-token")
+	conf := config.New("xoxb-slack-token", "xapp-slack-app-token")
 	conf.UserToken = "invalid-token"
 	_, err := conf.Platform()
 	assert.Error(t, err)
-	if cfgErr, ok := err.(*bot.ConfigError); ok {
-		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
-	} else if cfgErr, ok := err.(*confpkg.ConfigError); ok {
+	if cfgErr, ok := err.(*config.ConfigError); ok {
 		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
 	} else {
 		t.Fatalf("expected ConfigError, got %T", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ func TestNew(t *testing.T) {
 		t.Fatal(err)
 	}
 	conf := New("xoxb-slack-token", "xapp-slack-app-token")
+	conf.UserToken = "xoxp-slack-user-token"
 	conf.ScriptDir = dir
 	platform, err := conf.Platform()
 	assert.NoError(t, err)
@@ -38,4 +39,15 @@ func TestNewDiscordShareHost(t *testing.T) {
 	assert.Equal(t, Discord, platform)
 	assert.Empty(t, conf.Scripts())
 	assert.True(t, conf.ShareEnabled())
+}
+
+func TestSlackUserTokenRequired(t *testing.T) {
+	conf := New("xoxb-slack-token", "xapp-slack-app-token")
+	_, err := conf.Platform()
+	assert.Error(t, err)
+	if cfgErr, ok := err.(*ConfigError); ok {
+		assert.Equal(t, "INVALID_SLACK_USER_TOKEN", cfgErr.Code)
+	} else {
+		t.Fatalf("expected ConfigError, got %T", err)
+	}
 }


### PR DESCRIPTION
## Summary
- require Slack user token and validate `xoxp-` prefix
- document Slack user token as required across config, CLI, and README
- add test for missing Slack user token

## Testing
- `make fmt`
- `make test` *(fails: signal SIGSEGV: segmentation violation)*
- `go test ./config`


------
https://chatgpt.com/codex/tasks/task_e_689170a744188325a531f2c905908483