### PR TITLE
Add Shift-Tab keystroke support to REPLbot

### DIFF
--- a/bot/session.go
+++ b/bot/session.go
@@ -76,7 +76,7 @@ const (
 		"  `!e TEXT` - Sends _TEXT_ (interprets _\\n_, _\\r_, _\\t_, _\\b_ & _\\x.._)\n\n" +
 		"Sending keys (can be combined):\n" +
 		"  `!r` - Return key\n" +
-		"  `!t`, `!tt` - Tab / double-tab\n" +
+		"  `!t`, `!tt`, `!s-tab` - Tab / double-tab / shift-tab\n" +
 		"  `!up`, `!down`, `!left`, `!right` - Cursor\n" +
 		"  `!pu`, `!pd` - Page up / page down\n" +
 		"  `!a`, `!b`, `!c`, `!d`, `!c-..` - Ctrl-..\n" +
@@ -114,6 +114,7 @@ var (
 		"!d":     "^D",
 		"!t":     "\t",
 		"!tt":    "\t\t",
+		"!s-tab": "btab",   // Shift-Tab
 		"!esc":   "escape", // ESC
 		"!up":    "up",     // Cursor up
 		"!down":  "down",   // Cursor down


### PR DESCRIPTION
## Summary
- Added `\!s-tab` command to send Shift-Tab (backward tab) to tmux sessions
- Maps to tmux's `btab` key binding for proper Shift-Tab functionality
- Updated help message to document the new keystroke command

## Changes
- Added `"\!s-tab": "btab"` to the `sendKeysMapping` in `bot/session.go`
- Updated help text to include `\!s-tab` alongside existing tab commands

## Test plan
- [ ] Test `\!s-tab` command sends Shift-Tab correctly to active REPL session
- [ ] Verify help message displays the new command
- [ ] Test in applications that use Shift-Tab for backward navigation (e.g., command completion)

🤖 Generated with [Claude Code](https://claude.ai/code)